### PR TITLE
fixes findAlbumURLs for artists with default album for /music

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,7 +36,7 @@ var parseSearchResults = function(body) {
     result.link = $resultItem.find('.itemurl').text().trim();
     if ($resultItem.find('.art img').length > 0) {
       result.image = $resultItem.find('.art img').attr('src');
-    }        
+    }
     if ($resultItem.find('.tags').length > 0) {
       var tags = $resultItem.find('.tags').text().replace('tags:', '').replace(/\s/g, '');
       result.tags = tags.length > 1 ? tags.split(',') : [];
@@ -88,7 +88,7 @@ var findAlbumURLs = function(body, artistURL) {
     links = $("span.indexpage_list_cell").find('a');
   } else if ( $(".music-grid li").length > 0) {
     links = $(".music-grid li").find('a');
-  }  
+  }
   if (typeof links != "undefined") {
     for (var i = 0; i < links.length; i++) {
       var href = $(links[i]).attr('href');
@@ -102,13 +102,27 @@ var findAlbumURLs = function(body, artistURL) {
     };
   } // option 2. the artist has only one album and its on the artist page
   else {
-    var formatText = $('.buyItem').first().find('.buyItemPackageTitle').text().trim();
-    var format = formatText.replace('Digital ', '').toLowerCase();
-    var albumTitle = $('#name-section .trackTitle').text().trim().toLowerCase();
-    if (albumTitle.length > 0 && format.length > 0) {
-      var albumSlug = slug(albumTitle);
-      var albumURL = url.resolve(artistURL, '/' + format + '/' + albumSlug);
-      results.push(albumURL);
+    links = $("#discography ul li").find('a');
+    if (typeof links != "undefined") {
+      for (var i = 0; i < links.length; i++) {
+        var href = $(links[i]).attr('href');
+        // only keep relative path (don't get out of bandcamp.com)
+        if (! /https?:\/\//i.exec(href)) {
+          var albumURL = url.resolve(artistURL, href);
+          if (results.indexOf(albumURL) == -1) {
+            results.push(albumURL);
+          }
+        }
+      };
+    } else {
+      var formatText = $('.buyItem').first().find('.buyItemPackageTitle').text().trim();
+      var format = formatText.replace('Digital ', '').toLowerCase();
+      var albumTitle = $('#name-section .trackTitle').text().trim().toLowerCase();
+      if (albumTitle.length > 0 && format.length > 0) {
+        var albumSlug = slug(albumTitle);
+        var albumURL = url.resolve(artistURL, '/' + format + '/' + albumSlug);
+        results.push(albumURL);
+      }
     }
   }
 
@@ -116,7 +130,7 @@ var findAlbumURLs = function(body, artistURL) {
 }
 
 
-var parseAlbumProducts = function(body, albumURL) {  
+var parseAlbumProducts = function(body, albumURL) {
   var results = [],
     $ = cheerio.load(body);
 
@@ -198,7 +212,7 @@ var parseAlbumProducts = function(body, albumURL) {
           result.nameYourPrice = true;
         }
       }
-      
+
       // remaining
       var remainingText = $item.find('.notable.end').text().replace(/\D/g, '');
       if (remainingText.length > 0) {


### PR DESCRIPTION
This fixes this case.

Script:
```js
#!/usr/bin/env node

var bandcamp = require('bandcamp-scraper');

var artistURL = "http://joshwhelchel.com/";
bandcamp.getArtistAlbumURLs(artistURL, function(error, results) {
  if (error) {
    console.log(error);
  } else {
    console.log(results);
  }
});
```

**Before fix:**
```js
[ 'http://joshwhelchel.com/album/oblitus' ]
```

**After fix:***
```js
[ 'http://joshwhelchel.com/album/oblitus',
  'http://joshwhelchel.com/album/ravenmark-scourge-of-estellion-original-soundtrack',
  'http://joshwhelchel.com/album/gungirl-2-original-soundtrack',
  'http://joshwhelchel.com/album/the-spirit-engine-2-complete-original-soundtrack',
  'http://joshwhelchel.com/album/rise-of-the-blobs-original-soundtrack',
  'http://joshwhelchel.com/album/bonesaw-original-soundtrack',
  'http://joshwhelchel.com/album/jottobots-original-sound',
  'http://joshwhelchel.com/album/wind-up-knight-soundtrack',
  'http://joshwhelchel.com/track/the-light-of-the-darkness-theme',
  'http://joshwhelchel.com/track/so-blue-feat-amanda-appiarius',
  'http://joshwhelchel.com/track/zeldas-first-trip-to-the-village',
  'http://joshwhelchel.com/album/the-spirit-engine-original-soundtrack',
  'http://joshwhelchel.com/track/dies-nox-et-omnia-feat-ryan-c-connelly-and-danielle-messina',
  'http://joshwhelchel.com/track/get-loud-feat-ryan-c-connelly',
  'http://joshwhelchel.com/track/space-sushi-cant-swim-in-four-loko',
  'http://joshwhelchel.com/album/skullpogo-original-soundtrack',
  'http://joshwhelchel.com/album/the-spirit-engine-2-selections',
  'http://joshwhelchel.com/album/stories-vol-1-2001-2008',
  'http://joshwhelchel.com/album/premonitions-vol-1-selections',
  'http://joshwhelchel.com/album/premonitions-vol-2-calling-of-fate',
  'http://joshwhelchel.com/album/premonitions-vol-3-the-few-who-cross-a-world',
  'http://joshwhelchel.com/album/premonitions-vol-4-a-lost-dream' ]
```