### PR TITLE
Add missing schema for labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 The scraper allow you to:
 
-- search `artist`, `album`, `track`, `fan`
+- search `artist`, `album`, `track`, `fan`, `label`
 - get album urls from an artist url
 - get album info from an album url
 - get album products from an album url
@@ -42,7 +42,7 @@ Search any resources that matches the given `params.query` for the current `para
 
 #### Search Results
 
-An array of resources that have different properties depending on their _type_ property: **artist**, **album**, **track** or **fan**.
+An array of resources that have different properties depending on their _type_ property: **artist**, **album**, **track**, **fan**, or **label**.
 
 Every resource matches the [search-result JSON schema](/schemas/search-result.json).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bandcamp-scraper",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A scraper for https://bandcamp.com",
   "main": "lib/index.js",
   "scripts": {

--- a/schemas/search-result.json
+++ b/schemas/search-result.json
@@ -124,7 +124,7 @@
         }
       },
       "required": [ "type", "name", "url", "imageUrl", "tags" ]
-    },
+    }
   },
   "title" : "search-result",
   "description" : "The JSON schema that matches a search result.",

--- a/schemas/search-result.json
+++ b/schemas/search-result.json
@@ -101,7 +101,30 @@
         "genre": { "type": "string" }
       },
       "required": [ "type", "name", "url", "imageUrl", "tags", "genre" ]
-    }
+    },
+    "label": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string" },
+        "name": { "type": "string" },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "imageUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [ "type", "name", "url", "imageUrl", "tags" ]
+    },
   },
   "title" : "search-result",
   "description" : "The JSON schema that matches a search result.",
@@ -110,6 +133,7 @@
     { "$ref": "#/definitions/artist" },
     { "$ref": "#/definitions/album" },
     { "$ref": "#/definitions/track" },
-    { "$ref": "#/definitions/fan" }
+    { "$ref": "#/definitions/fan" },
+    { "$ref": "#/definitions/label" }
   ]
 }


### PR DESCRIPTION
I think this was added after the development of this scraper was completed. If this schema is missing, search will fail with an error if there's a label in search results.