### PR TITLE
fixed the bug for parseAlbumRawInfo

### DIFF
--- a/lib/htmlParser.js
+++ b/lib/htmlParser.js
@@ -248,7 +248,7 @@ exports.parseAlbumInfo = function (html, albumUrl) {
 
 
 // parse album info  hidden in the javascript
-var trRegex = /var TralbumData = ({[\s\S]*is_band_member: (true|false|null)\s+});/;
+var trRegex = /var TralbumData = ({[\s\S]*cfg_territory_support_on: (true|false|null)\s+});/;
 var urlCleanupRegex = /url:\s"([^"]+)"(?:\s+\+\s+)?"([^"]+)",/g;
 var cleanupCommentRegex = /\s?(\/\/\s[^\n]+)/g;
 var jsonifyKeyRegex = /\s\s([a-zA-Z\_]+)\s?\:\s([^,]+)(,|\s)/g;


### PR DESCRIPTION
The object "TralbumData" that "parseAlbumRawInfo" scrapes for was updated by bandcamp and it seems that the property "cfg_territory_support_on:" was added to the object causing the validation to fail and return null. I updated the regex at line 251 in htmlParser.js to check for the property "cfg_territory_support_on:" instead of "is_band_member:" and it seems to have fixed the error.