### PR TITLE
include tags in getAlbumInfo result, also don't require imageUrl

### DIFF
--- a/lib/htmlParser.js
+++ b/lib/htmlParser.js
@@ -224,6 +224,16 @@ exports.parseAlbumInfo = function (html, albumUrl) {
             }
           }
         },
+        tags: {
+          listItem: ".tag",
+          data: {
+            name: {
+              convert: function (tag) {
+                return tag;
+              }
+            }
+          }
+        },
         tracks: {
           listItem: 'table#track_table tr.track_row_view',
           data: {
@@ -250,7 +260,7 @@ exports.parseAlbumInfo = function (html, albumUrl) {
       }
     }
   });
-  var object = assignProps(data.album, {}, ['artist', 'title', 'imageUrl', 'tracks']);
+  var object = assignProps(data.album, {}, ['tags', 'artist', 'title', 'imageUrl', 'tracks']);
   // Remove undefined/null properties.
   for (var i = 0; i < object.tracks.length; i++) {
     // Remove tracks properties.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bandcamp-scraper",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "A scraper for https://bandcamp.com",
   "main": "lib/index.js",
   "scripts": {

--- a/schemas/album-info.json
+++ b/schemas/album-info.json
@@ -10,6 +10,14 @@
         "duration": { "type": "string" }
       },
       "required": [ "name" ]
+    },
+    "tag": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" }
+      },
+      "required": [ "name" ]
     }
   },
   "title" : "album-info",
@@ -28,6 +36,10 @@
     "tracks": {
       "type": "array",
       "items": { "$ref": "#/definitions/track" }
+    },
+    "tags": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/tag" }
     },
     "raw": {
       "type": "object"

--- a/schemas/album-info.json
+++ b/schemas/album-info.json
@@ -45,5 +45,5 @@
       "type": "object"
     }
   },
-  "required": [ "artist", "title", "url", "imageUrl", "tracks", "raw" ]
+  "required": [ "artist", "title", "url", "tracks", "raw" ]
 }


### PR DESCRIPTION
1. Includes `tags` key in `getAlbumInfo` response
2. Removes `imageUrl` from the required attributes in the schema - it is not present on some albums and it's not necessary to error out the scraper just because one field is missing
3. bumps version