### PR TITLE
Add support for preview albums (issue #50)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log*
 node_modules
 .npm
 .DS_Store
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ npm-debug.log*
 node_modules
 .npm
 .DS_Store
-package-lock.json

--- a/lib/htmlParser.js
+++ b/lib/htmlParser.js
@@ -238,7 +238,6 @@ exports.parseAlbumInfo = function (html, albumUrl) {
           listItem: 'table#track_table tr.track_row_view',
           data: {
             name: {
-              // selector: 'span.track-title'
               selector: 'span.track-title'
             },
             url: {

--- a/lib/htmlParser.js
+++ b/lib/htmlParser.js
@@ -238,6 +238,7 @@ exports.parseAlbumInfo = function (html, albumUrl) {
           listItem: 'table#track_table tr.track_row_view',
           data: {
             name: {
+              // selector: 'span.track-title'
               selector: 'span.track-title'
             },
             url: {
@@ -262,6 +263,12 @@ exports.parseAlbumInfo = function (html, albumUrl) {
   });
   var object = assignProps(data.album, {}, ['tags', 'artist', 'title', 'imageUrl', 'tracks']);
   // Remove undefined/null properties.
+
+  // Quick fix for issue #50 : ignore non-playable tracks overall. 
+  // You might want to still send back their names in the future, 
+  // but then you'd have to fetch them differently as these don't have the class .track-title
+  object.tracks = object.tracks.filter(x => x.name !== '');
+
   for (var i = 0; i < object.tracks.length; i++) {
     // Remove tracks properties.
     for (var key in object.tracks[i]) {

--- a/lib/htmlParser.js
+++ b/lib/htmlParser.js
@@ -238,7 +238,6 @@ exports.parseAlbumInfo = function (html, albumUrl) {
           listItem: 'table#track_table tr.track_row_view',
           data: {
             name: {
-              // selector: 'span.track-title'
               selector: 'span.track-title'
             },
             url: {
@@ -263,12 +262,6 @@ exports.parseAlbumInfo = function (html, albumUrl) {
   });
   var object = assignProps(data.album, {}, ['tags', 'artist', 'title', 'imageUrl', 'tracks']);
   // Remove undefined/null properties.
-
-  // Quick fix for issue #50 : ignore non-playable tracks overall. 
-  // You might want to still send back their names in the future, 
-  // but then you'd have to fetch them differently as these don't have the class .track-title
-  object.tracks = object.tracks.filter(x => x.name !== '');
-
   for (var i = 0; i < object.tracks.length; i++) {
     // Remove tracks properties.
     for (var key in object.tracks[i]) {

--- a/lib/htmlParser.js
+++ b/lib/htmlParser.js
@@ -238,6 +238,7 @@ exports.parseAlbumInfo = function (html, albumUrl) {
           listItem: 'table#track_table tr.track_row_view',
           data: {
             name: {
+              // selector: 'span.track-title'
               selector: 'span.track-title'
             },
             url: {
@@ -262,6 +263,12 @@ exports.parseAlbumInfo = function (html, albumUrl) {
   });
   var object = assignProps(data.album, {}, ['tags', 'artist', 'title', 'imageUrl', 'tracks']);
   // Remove undefined/null properties.
+
+  // Quick fix for issue #50 : ignore non-playable tracks overall. 
+  // You might want to still send back their names in the future, 
+  //but then you'd have to fetch them differently as these don't have the class .track-title
+  object.tracks = object.tracks.filter(x => x.name !== '');
+
   for (var i = 0; i < object.tracks.length; i++) {
     // Remove tracks properties.
     for (var key in object.tracks[i]) {


### PR DESCRIPTION
Instead of ignoring non-playable tracks, it could be possible to add a different mechanic for these in the future, and indeed fetch their name. In the mean time, this fix prevents throwing an error when fetching these preview albums.